### PR TITLE
修正了关于node-glob match pattern的一个描述错误

### DIFF
--- a/doc/docs/api/config-glob.md
+++ b/doc/docs/api/config-glob.md
@@ -19,8 +19,8 @@ FIS3 中支持的 glob 规则，FIS3 使用 [node-glob](https://github.com/isaac
 当设置规则时，没有严格的以 `/` 开头，比如 `a.js`, 它匹配的是所有目录下面的 `a.js`, 包括：`/a.js`、`/a/a.js`、`/a/b/a.js`。 如果要严格只命中根目录下面的 `/a.js`, 请使用 `fis.match('/a.js')`。
 
 另外 `/foo/*.js`， 只会命中 `/foo` 目录下面的所有 js 文件，不包含子目录。
-而 `/foo/**/*.js` 是命中所有子目录以及其子目录下面的所有 js 文件，不包含当前目录下面的 js 文件。
-如果需要命中 `foo` 目录下面以及所有其子目录下面的 js 文件，请使用 `/foo/**.js`。
+而 `/foo/**/*.js` 是命中 `foo` 目录下面以及所有其子目录下面的 js 文件。
+FIS3扩展了这块的语法，除了使用`node-glob`的`/foo/**/*.js`, 也可以使用 `/foo/**.js`。
 
 
 ### 扩展的规则
@@ -28,6 +28,8 @@ FIS3 中支持的 glob 规则，FIS3 使用 [node-glob](https://github.com/isaac
 1. 假设匹配 `widget` 目录下以及其子目录下的所有 js 文件，使用 `node-glob` 需要这么写
 
   ```js
+  widget/**/*.js
+  或者
   widget/{*.js,**/*.js}
   ```
 


### PR DESCRIPTION
在node-glob (实测版本v5.0.14) pattern里 widget/**/*.js 是会连同widget目录下的以.js结尾的文件也match的，原文档中的描述有误
具体一个测试例子可以参考http://www.globtester.com/#p=eJzTL89MSU8t0dfS0tfSyyoGACbIBJs%3D&r=eJyzScksU0jOSSwutlXKTSxJzlCy0y%2FPTElPLdFPzE2sStXLKrbRB6qxs8FUaFNckJinUFxSmZNqq5Scn5NfZKVQlJ6kYWGko2BoYQEkLC00rRXS8vNKdIszq1KtgAJ6RgUV1gg7SlKLkS0CGWhnk1RkR3M703PykzAsJt9siJshpoCdDgBWqm8y&