### PR TITLE
删除Content-Length header

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1220,15 +1220,9 @@ _.upload = function(url, opt, data, content, subpath, callback) {
   collect.push(content);
   collect.push('--' + boundary + '--' + endl);
 
-  var length = 0;
-  collect.forEach(function(ele) {
-    length += ele.length;
-  });
-
   opt.method = opt.method || 'POST';
   opt.headers = _.assign({
-    'Content-Type': 'multipart/form-data; boundary=' + boundary,
-    'Content-Length': length
+    'Content-Type': 'multipart/form-data; boundary=' + boundary
   },opt.headers || {});
   opt = _.parseUrl(url, opt);
   var http = opt.protocol === 'https:' ? require('https') : require('http');


### PR DESCRIPTION
删除Content-Length header
某些条件下会使得node.js的multer报错，删除Content-Length字段可恢复正常
建议先删掉这个header字段
貌似省略这个字段影响不大

如下是multer的报错
```
Error: Unexpected end of multipart data
    at /xx/node_modules/multer/node_modules/busboy/node_modules/dicer/lib/Dicer.js:62:28
    at doNTCallback0 (node.js:417:9)
    at process._tickCallback (node.js:346:13)
```