### PR TITLE
修复File 对象 锚点跳转问题

### DIFF
--- a/doc/docs/build.md
+++ b/doc/docs/build.md
@@ -118,7 +118,7 @@ fis.match('*.es6', {
 
 其他插件扩展点亦然。
 
-### File 对象
+### File对象
 
 ```js
 function File(filepath) {


### PR DESCRIPTION
http://fis.baidu.com/fis3/docs/build.html#File%E5%AF%B9%E8%B1%A1 ,加了空格锚点跳不到指定位置
而这个是可以跳转到正确位置的：  http://fis.baidu.com/fis3/docs/build.html#File%20%E5%AF%B9%E8%B1%A1