### PR TITLE
make fis.hook 插件name keep lowercase

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -364,6 +364,8 @@ var Config = Object.derive(/** @lends fis.config.Config.prototype */{
   hook: function(name, settings) {
     var key = 'modules.hook';
     var origin = this.get(key);
+    
+    name = name.toLowerCase();
 
     if (origin) {
       origin = typeof origin === 'string' ? origin.split(/\s*,\s*/) : (Array.isArray(origin) ? origin : [origin]);
@@ -385,6 +387,8 @@ var Config = Object.derive(/** @lends fis.config.Config.prototype */{
   unhook: function(name) {
     var key = 'modules.hook';
     var origin = this.get(key);
+    
+    name = name.toLowerCase();
 
     if (origin) {
       origin = typeof origin === 'string' ? origin.split(/\s*,\s*/) : (Array.isArray(origin) ? origin : [origin]);


### PR DESCRIPTION
这个地方有些人会写成大小写不一的name。
在路径大小写不敏感的操作系统中不会有问题。
但是如果部署到大小写敏感的生产或测试环境中的时候，会引起找不到插件的error。
今天遇到了，就发个PR。。。