### PR TITLE
plugin 'image-set' should be a preprocessor

### DIFF
--- a/doc/docs/api/config-props.md
+++ b/doc/docs/api/config-props.md
@@ -438,7 +438,7 @@ fis.match('*.sass', {
 
 ```js
 fis.match('*.{css,less}', {
-    paser: fis.plugin('image-set')
+    preprocessor: fis.plugin('image-set')
 });
 ```
 


### PR DESCRIPTION
The plugin 'image-set' should be a preprocessor, instead of a parser.