### PR TITLE
记录被内嵌过的模板

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -762,6 +762,12 @@ function addDeps(a, b) {
       a.cache.mergeDeps(b.cache);
     }
     a.cache.addDeps(b.realpath || b);
+    // 记录被内嵌过的模板
+    if(b.isHtmlLike || b.asyncs.isHtmlLike) {
+      b.map = {
+        pkg: a.getId()
+      };
+    }
   }
 }
 


### PR DESCRIPTION
您好！在使用fex-team提供的[fis3-deploy-skip-packed](https://github.com/fex-team/fis3-deploy-skip-packed)插件配合fis3进行发布时，发现一些被内嵌过的模块碎片也同时被发布了。
希望用于上线部署的目录中能够排除这些碎片文件，所以修改了一下compile.js。希望采纳或者添加类似的功能，谢谢！