### PR TITLE
修改 liftoff 的用法错误

### DIFF
--- a/bin/fis.js
+++ b/bin/fis.js
@@ -4,7 +4,6 @@ var Liftoff = require('liftoff');
 var argv = require('minimist')(process.argv.slice(2));
 var path = require('path');
 var cli = new Liftoff({
-  name: 'fis3',
   processTitle: 'fis',
   moduleName: 'fis3',
   configName: 'fis-conf',


### PR DESCRIPTION
根据 https://github.com/js-cli/js-liftoff#optsname

name 只是设置 processTitle, moduleName, configName 的糖，然而在这里 processTitle,
moduleName, configName 后面都已经设置了，所以这里的 name 是完全无意义的。