### PR TITLE
Update config-props.md

### DIFF
--- a/doc/docs/api/config-props.md
+++ b/doc/docs/api/config-props.md
@@ -426,7 +426,7 @@ fis.match('*.less', {
 
 ```js
 fis.match('*.sass', {
-    parser: fis.plugin('sass'), //启用fis-parser-sass插件
+    parser: fis.plugin('node-sass'), //启用fis-parser-node-sass插件
     rExt: '.css'
 });
 ```


### PR DESCRIPTION
更新示例中编译 sass 的插件为`fis-parser-node-sass`,原`fis-parser-sass`已停止维护。