### PR TITLE
feat: 增加cli.options, 允许外部修改help提示

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -35,6 +35,20 @@ cli.commander = null;
 cli.info = fis.util.readJSON(path.dirname(__dirname) + '/package.json');
 
 /**
+ * 支持命令合集
+ * @memberOf fis.cli
+ * @name options
+ */
+cli.options = {
+  '-h, --help': 'print this help message',
+  '-v, --version': 'print product version and exit',
+  '-r, --root <path>': 'specify project root',
+  '-f, --file <filename>': 'specify the file path of `fis-conf.js`',
+  '--no-color': 'disable colored output',
+  '--verbose': 'enable verbose mode'
+};
+
+/**
  * 显示帮助信息，主要用来格式化信息，处理缩进等。fis command 插件，可以用此方法来输出帮助信息。
  *
  * @param  {String} [cmdName]  命令名称
@@ -59,14 +73,7 @@ cli.help = function(cmdName, options, commands) {
       commands[name] = cmd.desc || '';
     });
 
-    options =  {
-      '-h, --help': 'print this help message',
-      '-v, --version': 'print product version and exit',
-      '-r, --root <path>': 'specify project root',
-      '-f, --file <filename>': 'specify the file path of `fis-conf.js`',
-      '--no-color': 'disable colored output',
-      '--verbose': 'enable verbose mode'
-    };
+    options =  cli.options;
   }
 
   options = options || {};


### PR DESCRIPTION
**原因：**

我这边自己封装了一套解决方案，扩展了命令，

为了 `fis3 -h` 时候显示新增命令的帮助信息

临时解决方案就是重写 cli.help 函数

----

所以这里就想开放 `cli.options` 自定义