### PR TITLE
_.map的方法注释中，源对象和目标对象写反了

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -140,7 +140,7 @@ _.is = function(source, type) {
 };
 
 /**
- * 对象枚举元素遍历，若merge为true则进行_.assign(obj, callback)，若为false则回调元素的key value index
+ * 对象枚举元素遍历，若merge为true则进行_.assign(callback, obj)，若为false则回调元素的key value index
  * @param  {Object}   obj      源对象
  * @param  {Function|Object} callback 回调函数|目标对象
  * @param  {Boolean}   merge    是否为对象赋值模式


### PR DESCRIPTION
源对象是obj，目标对象是callback，是将obj上的自有可枚举属性浅复制到callback上