### PR TITLE
fix: ignore empty files when release

### DIFF
--- a/lib/release.js
+++ b/lib/release.js
@@ -67,7 +67,8 @@ var exports = module.exports = function(opt, callback) {
   var collect = function(file, type) {
     type = type || 'res';
 
-    if (file.release && file.useMap) {
+    // ignore empty files
+    if (file.release && file.useMap && file.getContent().length) {
       //add resource map
       var id = file.getId();
       ret.ids[id] = file;


### PR DESCRIPTION
编译时忽略空文件，无需添加到资源表，否则导致某些cdn报404。