### PR TITLE
修改set与get路径处理不同导致存取值不同的差异问题

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -106,7 +106,8 @@ var Config = Object.derive(/** @lends fis.config.Config.prototype */{
   },
   _get: function(path) {
     var result = this.data;
-    (path || '').split('.').forEach(function(key) {
+    path = String(path || '').trim(); 
+    path.split('.').forEach(function(key) {
       if (key && (typeof result !== 'undefined')) {
         result = result[key];
       }


### PR DESCRIPTION
发现代码的set的path处理是String(path || '').trim()而get的path只是简单的(path || '')，会导致存储差异问题。
eg：
fis.set('  key', 'value')
fis.get('  key')  // undefined
fis.get('key')  // 'value'