### PR TITLE
fix upload error

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1268,6 +1268,9 @@ _.upload = function(url, opt, data, content, subpath, callback) {
         callback(err.message || err);
       });
   });
+  req.on('error', function(err) {
+    callback(err.message || err);
+  });
   collect.forEach(function(d) {
     req.write(d);
   });


### PR DESCRIPTION
Add onerror function to _.upload, or the http-push plugin will halt without retry even configured. This happens quite a lot and you will see a few successful uploads followed by server rejection.