### PR TITLE
修复#1271

### DIFF
--- a/lib/project.js
+++ b/lib/project.js
@@ -75,27 +75,31 @@ exports.getSourceByPatterns = function(patterns, opts) {
 
   var ret = [];
   var source = {};
-
+  var unret = [];
+  var hasIncloud = false;
   patterns.forEach(function(pattern, index) {
     var exclude = pattern.substring(0, 1) === '!';
-
-    if (exclude) {
-      pattern = pattern.substring(1);
-
-      // 如果第一个规则就是排除用法，都没有获取结果就排除，这是不合理的用法。
-      // 不过为了保证程序的正确性，在排除之前，通过 `**` 先把所有文件获取到。
-      // 至于性能问题，请用户使用时规避。
-      (index === 0) && (ret = glob.sync('**', opts));
-    }
+    exclude && (pattern = pattern.substring(1));
 
     // glob 列文件规则带 / 表现不对。
     pattern[0] === '/' && (pattern = pattern.substring(1));
 
     var mathes = glob.sync(pattern, opts);
-
-    ret = _[exclude ? 'difference' : 'union'](ret, mathes);
+    if (exclude) {
+        unret = _.union(unret, mathes);
+        return;
+    }
+    hasIncloud = true;
+    ret = _.union(ret, mathes);
   });
+  // 如果project.files只有过滤文件，没有包含文件则认为包含所有文件
+  if (!hasIncloud) {
+      ret = ret.length ? ret : glob.sync('**', opts); 
+  }
+  // 在包含文件中过滤掉 过滤规则的文件
+  ret = _.difference(ret, unret);
 
+    console.log(ret);
   ret.forEach(function(file) {
     file = fis.file(opts.cwd, file);
     if (file.release && !file.isDir()) {


### PR DESCRIPTION
在forEach中进行过滤会导致 由先后顺序引起的过滤失败问题。
修改过滤规则到forEach之外进行。

新增hasIncloud用来判断project.files是否只包含过滤规则，从而保证和之前的index===0执行glob.sync('**',opts)规则相同。