### PR TITLE
修复 nodejs v14及后续版本执行 fis3 release 出错的问题

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -724,6 +724,10 @@ _.write = function(path, data, charset, append) {
   if (!_exists(path)) {
     _.mkdir(_.pathinfo(path).dirname);
   }
+  // 兼容 nodejs v14 及后续版本
+  if (data === undefined || data === null || typeof data === 'number') {
+    data += '';
+  }
   if (charset) {
     data = getIconv().encode(data, charset);
   }


### PR DESCRIPTION
fs.writeFileSync(path, data) 在 nodejs v14及后续版本中有相关的调整，（https://nodejs.org/docs/latest-v14.x/api/fs.html#fs_fs_writefilesync_file_data_options），这会导致fis3 release 在缓存 fis-conf.js 文件时、fis3 server start 在保存 pid 时出现错误，本次变更用于修复这些错误。